### PR TITLE
array filter updated to receive false as an excepted value

### DIFF
--- a/src/Helper/ArrayHelper.php
+++ b/src/Helper/ArrayHelper.php
@@ -1,15 +1,13 @@
 <?php
 
-
 namespace Afiqiqmal\HuaweiPush\Helper;
-
 
 class ArrayHelper
 {
     static function filter($array)
     {
         return array_filter($array, function ($var) {
-            return ($var !== NULL && $var !== FALSE && $var !== '');
+            return ($var !== NULL && $var !== '');
         });
     }
 }


### PR DESCRIPTION
Properties with value `false` should not be removed during array conversion. `false` can be an important value for notification payload. For example, the property `foreground_show` has a default value as `true`, that means if you do not include this property in payload Huawei will consider this as `true`. Now if I want to set this value as `false`, it's not possible because the `ArrayHelper` class omits the false values. 
Reference- https://developer.huawei.com/consumer/en/doc/development/HMSCore-Guides-V5/android-fgrd-show-0000001050040126-V5?ha_source=hms1

That's why excluded the false value checking from `ArrayHelper` class.

fixes #1